### PR TITLE
LBP-73 Better handling for month-only dates & text sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lookbooks/report-formatter",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Format default presentation of tabulated report data.",
   "author": "Gleb Varenov <kuzzdra@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lookbooks/report-formatter",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Format default presentation of tabulated report data.",
   "author": "Gleb Varenov <kuzzdra@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lookbooks/report-formatter",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Format default presentation of tabulated report data.",
   "author": "Gleb Varenov <kuzzdra@gmail.com>",
   "license": "MIT",

--- a/src/ReportDataSource.js
+++ b/src/ReportDataSource.js
@@ -221,7 +221,11 @@ export class ReportDataSource {
      * @type {Formatters}
      **/
     const formatters = {
-      number: null,
+      number: new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+        style: "decimal"
+      }),
       ...overrideFormatters,
     };
 

--- a/src/ReportDataSource.js
+++ b/src/ReportDataSource.js
@@ -153,8 +153,14 @@ export class ReportDataSource {
                 // object from it by Date constructor like in other options.
                 // Thus, the lame hack with extending it to something
                 // Date.parse() would understand.
+                let dateValue;
+                if (new Date(value) === "Invalid Date" || isNaN(new Date(value))) {
+                  dateValue = new Date(`${value} 2000`).valueOf();
+                } else {
+                  dateValue = new Date(value).valueOf();
+                }
                 value = formatters.month
-                  ? formatters.month.format(new Date(`${value} 2000`).valueOf())
+                  ? formatters.month.format(dateValue)
                   : String(value);
                 break;
               case "month-year":

--- a/src/processReportData.js
+++ b/src/processReportData.js
@@ -489,8 +489,8 @@ export function sortProcessedResults(definition, processed) {
         case "name":
           sf.valueGetter = (a, b) => {
             return {
-              aValue: a[sort.key].toLowerCase(),
-              bValue: b[sort.key].toLowerCase(),
+              aValue: typeof a[sort.key] === 'string' ? a[sort.key].toLowerCase() : a[sort.key],
+              bValue: typeof b[sort.key] === 'string' ? b[sort.key].toLowerCase() : b[sort.key],
             };
           };
           break;

--- a/src/processReportData.js
+++ b/src/processReportData.js
@@ -506,9 +506,19 @@ export function sortProcessedResults(definition, processed) {
               break;
             case "month":
               sf.valueGetter = (a, b) => {
+                // If value is a month name, add a year so the date can be parsed
+                let aDate;
+                let bDate;
+                if (new Date(a[sort.key]) === "Invalid Date" || isNaN(new Date(a[sort.key]))) {
+                  aDate = new Date(`${a[sort.key]} 2000`);
+                  bDate = new Date(`${b[sort.key]} 2000`);
+                } else {
+                  aDate = new Date(a[sort.key]);
+                  bDate = new Date(b[sort.key]);
+                }
                 return {
-                  aValue: new Date(a[sort.key]).getMonth(),
-                  bValue: new Date(b[sort.key]).getMonth(),
+                  aValue: aDate.getMonth(),
+                  bValue: bDate.getMonth()
                 };
               };
               break;

--- a/src/processReportData.js
+++ b/src/processReportData.js
@@ -484,6 +484,16 @@ export function sortProcessedResults(definition, processed) {
       });
 
       switch (sort.type) {
+        case "longtext":
+        case "shorttext":
+        case "name":
+          sf.valueGetter = (a, b) => {
+            return {
+              aValue: a[sort.key].toLowerCase(),
+              bValue: b[sort.key].toLowerCase(),
+            };
+          };
+          break;
         case "date":
           switch (sort.option) {
             case "year":


### PR DESCRIPTION
This will handle either a month name or a date when building cells and when sorting.
Sorting on text fields will be case insensititve.

It also includes some currency formatting that I missed committing on LBP-88